### PR TITLE
fix: resolve SyntaxWarning from invalid escape sequences

### DIFF
--- a/demos/歌单同步.py
+++ b/demos/歌单同步.py
@@ -2,11 +2,11 @@
 以下 .pyncm 即为你保存的登陆凭据
 ---
 使用例 : 同步个人创建的歌单到`NetEase/[专辑名]`
-    python .\demos\歌单同步.py --load .pyncm --quality hires --output NetEase/{album}
+    python ./demos/歌单同步.py --load .pyncm --quality hires --output NetEase/{album}
 使用例 : 同步个人创建+收藏的歌单到`NetEase/[专辑名]`,并保存 M3U 播放列表
-    python .\demos\歌单同步.py --load .pyncm --quality hires --output NetEase/{album} --user-bookmarks --save-m3u NetEase/PLAYLIST.m3u
+    python ./demos/歌单同步.py --load .pyncm --quality hires --output NetEase/{album} --user-bookmarks --save-m3u NetEase/PLAYLIST.m3u
 使用例 : 同步某一歌单到`NetEase/[专辑名]`
-    python .\demos\歌单同步.py --load .pyncm --quality hires --output NetEase/{album} https://music.163.com/playlist?id=988690134
+    python ./demos/歌单同步.py --load .pyncm --quality hires --output NetEase/{album} https://music.163.com/playlist?id=988690134
 '''
 from sys import argv
 from os import walk,path,remove

--- a/pyncm/__main__.py
+++ b/pyncm/__main__.py
@@ -471,10 +471,10 @@ def parse_sharelink(url):
         "分享mos9527创建的歌单「東方 PC」: http://music.163.com/playlist?id=72897851187" (desktop app)
         https://music.163.com/#/user/home?id=315542615 (user homepage)
     """
-    rurl = re.findall("(?:http|https):\/\/.*", url)
+    rurl = re.findall(r"(?:http|https):\/\/.*", url)
     if rurl:
         url = rurl[0]  # Use first URL found. Otherwise use value given as is.
-    numerics = re.findall("\d{4,}", url)    
+    numerics = re.findall(r"\d{4,}", url)
     assert numerics != None, "未在链接中找到任何 ID"
     ids = numerics[:1]  # Only pick the first match
     table = {


### PR DESCRIPTION
```
/usr/lib/python3.12/site-packages/demos/歌单同步.py:1: SyntaxWarning: invalid escape sequence '\d'
/usr/lib/python3.12/site-packages/demos/歌单同步.py:1: SyntaxWarning: invalid escape sequence '\d'
/usr/lib/python3.12/site-packages/pyncm/__main__.py:474: SyntaxWarning: invalid escape sequence '\/'
/usr/lib/python3.12/site-packages/pyncm/__main__.py:477: SyntaxWarning: invalid escape sequence '\d'
/usr/lib/python3.12/site-packages/pyncm/__main__.py:474: SyntaxWarning: invalid escape sequence '\/'
/usr/lib/python3.12/site-packages/pyncm/__main__.py:477: SyntaxWarning: invalid escape sequence '\d'
```

>
> A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/dev/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+\.\d+") now emits a [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")). In a future Python version, [SyntaxError](https://docs.python.org/dev/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning). (Contributed by Victor Stinner in [gh-98401](https://github.com/python/cpython/issues/98401).)
>
ref: https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes