### PR TITLE
fix: change lyrics fetching method to GetTrackLyricsV1

### DIFF
--- a/pyncm/__main__.py
+++ b/pyncm/__main__.py
@@ -241,7 +241,7 @@ class TaskPoolExecutorThread(Thread):
                     )
                     # Downloading & Parsing lyrics
                     lrc = LrcParser()
-                    dLyrics = track.GetTrackLyricsNew(task.lyrics.id)
+                    dLyrics = track.GetTrackLyricsV1(task.lyrics.id)
                     for k in set(dLyrics.keys()) & (
                         {"lrc", "tlyric", "romalrc"} - task.lyrics.lrc_blacklist
                     ):  # Filtering LRCs


### PR DESCRIPTION
Updated method for fetching track lyrics from GetTrackLyricsNew to GetTrackLyricsV1.

```
[WARN] pyncm.main 下载失败 module 'pyncm.apis.track' has no attribute 'GetTrackLyricsNew'
```

740e4e7 将 track.py 中的 `GetTrackLyricsNew` 修改为 `GetTrackLyricsV1` 导致歌词无法正确获取